### PR TITLE
Support prefix scopes

### DIFF
--- a/fixtures/modules/simple/prefixed-main.js
+++ b/fixtures/modules/simple/prefixed-main.js
@@ -1,0 +1,19 @@
+import { firstElement } from 'utils-prefix/dom.js';
+import App from 'app-prefix/app.js';
+
+const ready = () => {
+    return new Promise((resolve) => {
+        document.addEventListener('DOMContentLoaded', () => {
+            const el = document.getElementById('app');
+            resolve(firstElement(el));
+        });
+    });
+};
+
+const start = async () => {
+    const el = await ready();
+    const app = new App(el);
+    app.render();
+    app.update();
+};
+start();

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,14 +1,22 @@
 import path from 'path';
 import fs from 'fs/promises';
 
+const isExternal = (str) => {
+    return str.substr(0, 7) === 'http://' || str.substr(0, 8) === 'https://';
+};
+
 const isBare = (str) => {
-    if (str.startsWith('/') || str.startsWith('./') || str.startsWith('../') || str.substr(0, 7) === 'http://' || str.substr(0, 8) === 'https://') {
+    if (str.startsWith('/') || str.startsWith('./') || str.startsWith('../') || isExternal(str)) {
         return false;
     }
     return true;
 };
 
 const isString = (str) => typeof str === 'string';
+
+const isScopePrefixed = (str) => {
+    return str[str.length - 1] === '/';
+};
 
 const validate = (map) => Object.keys(map.imports).map((key) => {
     const value = map.imports[key];
@@ -32,11 +40,13 @@ const fileReader = (pathname = '') => new Promise((resolve, reject) => {
     }).catch(reject);
 });
 
-
+let WORKING_DIRECTORY;
 const CACHE = new Map();
 
-export async function load(importMaps = []) {
+export async function load(importMaps = [], workingDirectory) {
     const maps = Array.isArray(importMaps) ? importMaps : [importMaps];
+
+    WORKING_DIRECTORY = workingDirectory || process.cwd();
 
     const mappings = maps.map((item) => {
         if (isString(item)) {
@@ -58,19 +68,53 @@ export function clear() {
     CACHE.clear();
 }
 
+function resolveEntry(resolveArgs, cachedEntry, suffix = '') {
+    if (isExternal(cachedEntry)) {
+        const resolvedpath = new URL(suffix, cachedEntry).href;
+        return {
+            path: resolvedpath,
+            namespace: resolveArgs.path,
+            external: true,
+        };
+    }
+
+    const resolvedpath = path.join(WORKING_DIRECTORY, cachedEntry, suffix);
+    return {
+        path: resolvedpath,
+        namespace: resolveArgs.namespace,
+        external: false,
+    };
+}
+
 export function plugin() {
     return {
         name: 'importMap',
         setup(build) {
             build.onResolve({ filter: /.*?/ }, (args) => {
                 if (CACHE.has(args.path)) {
-                    return {
-                        path: CACHE.get(args.path),
-                        namespace: args.path,
-                        external: true
-                    };
+                    const cachedPath = CACHE.get(args.path);
+                    return resolveEntry(args, cachedPath);
                 }
-                return {};
+
+                let prefixMatch;
+                CACHE.forEach((target, scope) => {
+                    if (prefixMatch) {
+                        return;
+                    }
+
+                    if (!isScopePrefixed(scope)) {
+                        return;
+                    }
+
+                    if (!args.path.startsWith(scope)) {
+                        return;
+                    }
+
+                    const scopeSuffix = args.path.substring(scope.length);
+                    prefixMatch = resolveEntry(args, target, scopeSuffix);
+                });
+
+                return prefixMatch || {};
             });
         },
     };

--- a/tap-snapshots/test-plugin.js-TAP.test.js
+++ b/tap-snapshots/test-plugin.js-TAP.test.js
@@ -92,8 +92,11 @@ function firstElement(element) {
   return element.firstElementChild;
 }
 
+// fixtures/modules/simple/lit-element/v2/lit-element.js
+var html = () => {
+};
+
 // fixtures/modules/simple/app/views.js
-import {html, css} from "./lit-element/v2";
 function view(items) {
   return html\`<p>Hello \${items[0]}!</p>\`;
 }
@@ -131,6 +134,73 @@ var App = class {
 var app_default = App;
 
 // fixtures/modules/simple/main.js
+var ready = () => {
+  return new Promise((resolve) => {
+    document.addEventListener("DOMContentLoaded", () => {
+      const el = document.getElementById("app");
+      resolve(firstElement(el));
+    });
+  });
+};
+var start = async () => {
+  const el = await ready();
+  const app2 = new app_default(el);
+  app2.render();
+  app2.update();
+};
+start();
+
+`
+
+exports[`test/plugin.js TAP plugin() - import map maps local prefixed imports > local prefixed imports 1`] = `
+// fixtures/modules/simple/utils/dom.js
+function replaceElement(target, element) {
+  target.replaceWith(element);
+  return element;
+}
+function firstElement(element) {
+  return element.firstElementChild;
+}
+
+// fixtures/modules/simple/app/views.js
+import {html, css} from "https://cdn.eik.dev/lit-element/v2";
+function view(items) {
+  return html\`<p>Hello \${items[0]}!</p>\`;
+}
+
+// fixtures/modules/simple/data/data.js
+function random(min, max) {
+  return Math.floor(min + Math.random() * (max + 1 - min));
+}
+function data() {
+  return [
+    random(0, 20),
+    random(20, 40),
+    random(40, 60),
+    random(60, 80),
+    random(80, 100)
+  ];
+}
+
+// fixtures/modules/simple/app/app.js
+var App = class {
+  constructor(root) {
+    this.root = root;
+  }
+  render() {
+    const items = data();
+    const el = view(items);
+    this.root = replaceElement(this.root, el);
+  }
+  update() {
+    setInterval(() => {
+      this.render();
+    }, 1e3);
+  }
+};
+var app_default = App;
+
+// fixtures/modules/simple/prefixed-main.js
 var ready = () => {
   return new Promise((resolve) => {
     document.addEventListener("DOMContentLoaded", () => {
@@ -209,6 +279,28 @@ var ready = () => {
 var start = async () => {
   const el = await ready();
   const app2 = new app_default(el);
+  app2.render();
+  app2.update();
+};
+start();
+
+`
+
+exports[`test/plugin.js TAP plugin() - import map maps remote prefixed imports > remote prefixed imports 1`] = `
+// fixtures/modules/simple/prefixed-main.js
+import {firstElement} from "https://cdn.eik.dev/utils-library/v0/dom.js";
+import App from "https://cdn.eik.dev/app/v0/app.js";
+var ready = () => {
+  return new Promise((resolve) => {
+    document.addEventListener("DOMContentLoaded", () => {
+      const el = document.getElementById("app");
+      resolve(firstElement(el));
+    });
+  });
+};
+var start = async () => {
+  const el = await ready();
+  const app2 = new App(el);
   app2.render();
   app2.update();
 };


### PR DESCRIPTION
Added support for prefixed scopes (trailing slash)
Also made it use locally resolved files and not always return them as externals

Is this of any interest?
