### PR TITLE
feat: Support full import map mapping

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -6,12 +6,12 @@ import merge from 'deepmerge';
 
 const isString = (str) => typeof str === 'string';
 
-const fileReader = (pathname = '') => new Promise((resolve, reject) => {
+const fileReader = (pathname = '') => new Promise((success, reject) => {
     const filepath = path.normalize(pathname);
     fs.readFile(filepath).then((file) => {
         try {
             const obj = JSON.parse(file);
-            resolve(obj);
+            success(obj);
         } catch (error) {
             reject(error);
         }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,61 +1,46 @@
-import path from 'path';
-import fs from 'fs/promises';
-
-const isBare = (str) => {
-    if (str.startsWith('/') || str.startsWith('./') || str.startsWith('../') || str.substr(0, 7) === 'http://' || str.substr(0, 8) === 'https://') {
-        return false;
-    }
-    return true;
-};
+import { URL } from 'node:url';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { parse, resolve } from '@import-maps/resolve';
+import merge from 'deepmerge';
 
 const isString = (str) => typeof str === 'string';
-
-const validate = (map) => Object.keys(map.imports).map((key) => {
-    const value = map.imports[key];
-
-    if (isBare(value)) {
-        throw Error(`Import specifier can NOT be mapped to a bare import statement. Import specifier "${key}" is being wrongly mapped to "${value}"`);
-    }
-
-    return { key, value };
-});
 
 const fileReader = (pathname = '') => new Promise((resolve, reject) => {
     const filepath = path.normalize(pathname);
     fs.readFile(filepath).then((file) => {
         try {
             const obj = JSON.parse(file);
-            resolve(validate(obj));
+            resolve(obj);
         } catch (error) {
             reject(error);
         }
     }).catch(reject);
 });
 
+let CACHE = {};
+let BASE_URL = {};
 
-const CACHE = new Map();
-
-export async function load(importMaps = []) {
+export async function load(importMaps = [], baseURL = 'http://localhost/') {
     const maps = Array.isArray(importMaps) ? importMaps : [importMaps];
 
     const mappings = maps.map((item) => {
         if (isString(item)) {
             return fileReader(item);
         }
-        return validate(item);
+        return item;
     });
 
-    await Promise.all(mappings).then((items) => {
-        items.forEach((item) => {
-            item.forEach((obj) => {
-                CACHE.set(obj.key, obj.value);
-            });
-        });
-    });
+    const loadedMaps = await Promise.all(mappings);
+
+    const mapObject = merge.all(loadedMaps);
+
+    BASE_URL = new URL(baseURL);
+    CACHE = parse(mapObject, BASE_URL);
 }
 
 export function clear() {
-    CACHE.clear();
+    CACHE = {};
 }
 
 export function plugin() {
@@ -63,9 +48,10 @@ export function plugin() {
         name: 'importMap',
         setup(build) {
             build.onResolve({ filter: /.*?/ }, (args) => {
-                if (CACHE.has(args.path)) {
+                const { resolvedImport, matched } = resolve(args.path, CACHE, BASE_URL);
+                if (matched) {
                     return {
-                        path: CACHE.get(args.path),
+                        path: resolvedImport.href,
                         namespace: args.path,
                         external: true
                     };

--- a/package.json
+++ b/package.json
@@ -37,5 +37,9 @@
     "eslint-plugin-import": "2.26.0",
     "semantic-release": "19.0.3",
     "tap": "16.2.0"
+  },
+  "dependencies": {
+    "@import-maps/resolve": "^1.0.1",
+    "deepmerge": "^4.2.2"
   }
 }

--- a/tap-snapshots/test/plugin.js.test.cjs
+++ b/tap-snapshots/test/plugin.js.test.cjs
@@ -9,11 +9,8 @@ exports[`test/plugin.js TAP plugin() - array of import map maps - should replace
 // fixtures/modules/simple/main.js
 import { firstElement } from "https://cdn.eik.dev/something/v666";
 
-// fixtures/modules/simple/utils/dom.js
-function replaceElement(target, element) {
-  target.replaceWith(element);
-  return element;
-}
+// fixtures/modules/simple/app/app.js
+import { replaceElement } from "https://cdn.eik.dev/something/v666";
 
 // fixtures/modules/simple/app/views.js
 import { html, css } from "https://cdn.eik.dev/lit-element/v2";
@@ -92,7 +89,7 @@ function firstElement(element) {
 }
 
 // fixtures/modules/simple/app/views.js
-import { html, css } from "./lit-element/v2";
+import { html, css } from "http://localhost/lit-element/v2";
 function view(items) {
   return html\`<p>Hello \${items[0]}!</p>\`;
 }
@@ -151,11 +148,8 @@ exports[`test/plugin.js TAP plugin() - import map maps non bare imports - should
 // fixtures/modules/simple/main.js
 import { firstElement } from "https://cdn.eik.dev/something/v666";
 
-// fixtures/modules/simple/utils/dom.js
-function replaceElement(target, element) {
-  target.replaceWith(element);
-  return element;
-}
+// fixtures/modules/simple/app/app.js
+import { replaceElement } from "https://cdn.eik.dev/something/v666";
 
 // fixtures/modules/simple/app/views.js
 import { html, css } from "https://cdn.eik.dev/lit-element/v2";
@@ -349,11 +343,8 @@ exports[`test/plugin.js TAP plugin() - input is a filepath to a map file and an 
 // fixtures/modules/simple/main.js
 import { firstElement } from "https://cdn.eik.dev/something/v666";
 
-// fixtures/modules/simple/utils/dom.js
-function replaceElement(target, element) {
-  target.replaceWith(element);
-  return element;
-}
+// fixtures/modules/simple/app/app.js
+import { replaceElement } from "https://cdn.eik.dev/something/v666";
 
 // fixtures/modules/simple/app/views.js
 import { html, css } from "https://cdn.eik.dev/lit-element/v2";

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -1,7 +1,7 @@
 import * as plugin from '../lib/plugin.js';
 import esbuild from 'esbuild';
-import path from 'path';
-import url from 'url';
+import path from 'node:path';
+import url from 'node:url';
 import tap from 'tap';
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
@@ -153,30 +153,6 @@ tap.test('plugin() - import specifier is a interior package path - should replac
     const code = bufferToString(result.outputFiles);
 
     t.matchSnapshot(clean(code), 'interior package path');
-
-    plugin.clear();
-    t.end();
-});
-
-tap.test('plugin() - import map maps address to a bare importer - should throw', async (t) => {
-    await plugin.load({
-        imports: {
-            'lit-element': 'https://cdn.eik.dev/lit-element/v2',
-            'lit-html/lit-html': 'https://cdn.eik.dev/lit-html/v2',
-            'lit-html': 'https://cdn.eik.dev/lit-html/v1',
-        }
-    });
-    
-    t.rejects(esbuild.build({
-        entryPoints: [simple],
-        bundle: true,
-        format: 'esm',
-        minify: false,
-        sourcemap: false,
-        target: ['esnext'],
-        plugins: [plugin.plugin()],
-        write: false,
-    }));
 
     plugin.clear();
     t.end();


### PR DESCRIPTION
This take use of a full featured import map parser instead of a home grown parser only supporting rewrite of the import statements without taking the fill spec into account.

BREAKING CHANGE: Module should now be spec compliant and this might break builds where parts of an import map might have been ignored. The `load()` do now also take a second argument for setting a base URL to be applied to relative import references.