### PR TITLE
feat: Make first argument to .load() the base URL

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -4,6 +4,7 @@ import fs from 'node:fs/promises';
 import { parse, resolve } from '@import-maps/resolve';
 import merge from 'deepmerge';
 
+const isNotString = (str) => typeof str !== 'string';
 const isString = (str) => typeof str === 'string';
 
 const fileReader = (pathname = '') => new Promise((success, reject) => {
@@ -18,10 +19,14 @@ const fileReader = (pathname = '') => new Promise((success, reject) => {
     }).catch(reject);
 });
 
-let CACHE = {};
 let BASE_URL = {};
+let CACHE = {};
 
-export async function load(importMaps = [], baseURL = 'http://localhost/') {
+export async function load(baseURL, importMaps = []) {
+    if (isNotString(baseURL)) {
+        throw new TypeError('First argument must be a URL string');
+    }
+
     const maps = Array.isArray(importMaps) ? importMaps : [importMaps];
 
     const mappings = maps.map((item) => {
@@ -40,6 +45,7 @@ export async function load(importMaps = [], baseURL = 'http://localhost/') {
 }
 
 export function clear() {
+    BASE_URL = {};
     CACHE = {};
 }
 

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -1,15 +1,12 @@
 import * as plugin from '../lib/plugin.js';
 import esbuild from 'esbuild';
-import path from 'node:path';
-import url from 'node:url';
+import { URL } from 'node:url';
 import tap from 'tap';
 
-const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
-const simple = `${__dirname}/../fixtures/modules/simple/main.js`;
-const basic = `${__dirname}/../fixtures/modules/basic/main.js`;
-const map = `${__dirname}/../fixtures/simple.map.json`;
-const err = `${__dirname}/../fixtures/faulty.map.json`;
-
+const simple = new URL('../fixtures/modules/simple/main.js', import.meta.url).pathname;
+const basic = new URL('../fixtures/modules/basic/main.js', import.meta.url).pathname;
+const map = new URL('../fixtures/simple.map.json', import.meta.url).pathname;
+const err = new URL('../fixtures/faulty.map.json', import.meta.url).pathname;
 
 /*
  * When running tests on Windows, the output code get some extra \r on each line.
@@ -26,7 +23,7 @@ const bufferToString = (buff) => {
 }
 
 tap.test('plugin() - basic module - should replace lit-element with CDN URL', async (t) => {
-    await plugin.load({
+    await plugin.load('http://localhost/', {
         imports: {
             'lit-element': 'https://cdn.eik.dev/lit-element/v2'
         }
@@ -52,7 +49,7 @@ tap.test('plugin() - basic module - should replace lit-element with CDN URL', as
 });
 
 tap.test('plugin() - simple module - should replace lit-element with CDN URL', async (t) => {
-    await plugin.load({
+    await plugin.load('http://localhost/', {
         imports: {
             'lit-element': 'https://cdn.eik.dev/lit-element/v2'
         }
@@ -78,7 +75,7 @@ tap.test('plugin() - simple module - should replace lit-element with CDN URL', a
 });
 
 tap.test('plugin() - import map maps non bare imports - should replace import statement with CDN URL', async (t) => {
-    await plugin.load({
+    await plugin.load('http://localhost/', {
         imports: {
             'lit-element': 'https://cdn.eik.dev/lit-element/v2',
             './utils/dom.js': 'https://cdn.eik.dev/something/v666'
@@ -105,7 +102,7 @@ tap.test('plugin() - import map maps non bare imports - should replace import st
 });
 
 tap.test('plugin() - import map maps address to a relative path - should replace import statement with relative path', async (t) => {
-    await plugin.load({
+    await plugin.load('http://localhost/', {
         imports: {
             'lit-element': './lit-element/v2',
         }
@@ -131,7 +128,7 @@ tap.test('plugin() - import map maps address to a relative path - should replace
 });
 
 tap.test('plugin() - import specifier is a interior package path - should replace with CDN URL', async (t) => {
-    await plugin.load({
+    await plugin.load('http://localhost/', {
         imports: {
             'lit-element': 'https://cdn.eik.dev/lit-element/v2',
             'lit-html/lit-html': 'https://cdn.eik.dev/lit-html/v2',
@@ -159,7 +156,7 @@ tap.test('plugin() - import specifier is a interior package path - should replac
 });
 
 tap.test('plugin() - array of import map maps - should replace import statements with CDN URLs', async (t) => {
-    await plugin.load([{
+    await plugin.load('http://localhost/', [{
         imports: {
             'lit-element': 'https://cdn.eik.dev/lit-element/v2'
         }
@@ -190,7 +187,7 @@ tap.test('plugin() - array of import map maps - should replace import statements
 });
 
 tap.test('plugin() - input is a filepath to a map file - should load map and replace import statements with CDN URLs', async (t) => {
-   await plugin.load(map);
+   await plugin.load('http://localhost/', map);
 
     const result = await esbuild.build({
         entryPoints: [simple],
@@ -212,7 +209,7 @@ tap.test('plugin() - input is a filepath to a map file - should load map and rep
 });
 
 tap.test('plugin() - input is a filepath to a map file and an inline map - should load map and replace import statements with CDN URLs', async (t) => {
-    await plugin.load([
+    await plugin.load('http://localhost/', [
         map,
         {
             imports: {
@@ -241,11 +238,16 @@ tap.test('plugin() - input is a filepath to a map file and an inline map - shoul
 });
 
 tap.test('plugin() - input is a filepath to a non existing map file - should throw', async (t) => {
-    t.rejects(plugin.load('./foo.map.json'), /ENOENT: no such file or directory, open 'foo.map.json'/);
+    t.rejects(plugin.load('http://localhost/', './foo.map.json'), /ENOENT: no such file or directory, open 'foo.map.json'/);
     t.end();
 });
 
 tap.test('plugin() - input is a filepath to a faulty map file - should throw', async (t) => {
-    t.rejects(plugin.load(err), /Unexpected end of JSON input/);
+    t.rejects(plugin.load('http://localhost/', err), /Unexpected end of JSON input/);
+    t.end();
+});
+
+tap.test('plugin() - first argument is not a String - should throw', async (t) => {
+    t.rejects(plugin.load([], []), /First argument must be a URL string/);
     t.end();
 });


### PR DESCRIPTION
BREAKING CHANGE: The first argument to the `.load()` method now takes a base URL which the import map parser will use when parsing.