### PR TITLE
fix: let next plugin try if module can't be mapped

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -70,7 +70,7 @@ export function plugin() {
                         external: true
                     };
                 }
-                return {};
+                return null;
             });
         },
     };


### PR DESCRIPTION
I noticed this issue when trying to combine [`@eik/esbuild-plugin`](https://github.com/eik-lib/esbuild-plugin) (which uses this internally) and [`@warp-ds/esbuild-plugin`](https://github.com/warp-ds/esbuild-plugin). The Warp plugin was added after Eik, and its `onResolve` never got called (which rendered it unusable).